### PR TITLE
No payload pattern

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export function isType<P>(
 
 export interface ActionCreator<P> {
   type: string;
-  (payload: P, meta?: Object | null): Action<P>;
+  (payload?: P, meta?: Object | null): Action<P>;
 }
 
 export interface EmptyActionCreator extends ActionCreator<undefined> {


### PR DESCRIPTION
I guess I can't create no argument actionCreators now.

```javascript
const actionCreator = actionCreatorFactory();
const ping = actionCreator<{}>("PING");
ping() // error!
```

And I guess just what I want is that payload becomes optional parameter.