### PR TITLE
support payload-less async action creator

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -29,11 +29,24 @@ export interface AsyncActionCreators<P, S, E> {
     done: ActionCreator<Success<P, S>>;
     failed: ActionCreator<Failure<P, E>>;
 }
+export interface EmptySuccess<S> {
+    result: S;
+}
+export interface EmptyFailure<E> {
+    error: E;
+}
+export interface EmptyAsyncActionCreators<S, E> {
+    type: string;
+    started: EmptyActionCreator;
+    done: ActionCreator<EmptySuccess<S>>;
+    failed: ActionCreator<EmptyFailure<E>>;
+}
 export interface ActionCreatorFactory {
     (type: string, commonMeta?: Object | null, error?: boolean): EmptyActionCreator;
     <P>(type: string, commonMeta?: Object | null, isError?: boolean): ActionCreator<P>;
     <P>(type: string, commonMeta?: Object | null, isError?: (payload: P) => boolean): ActionCreator<P>;
     async<P, S>(type: string, commonMeta?: Object | null): AsyncActionCreators<P, S, any>;
+    async<undefined, S, E>(type: string, commonMeta?: Object | null): EmptyAsyncActionCreators<S, E>;
     async<P, S, E>(type: string, commonMeta?: Object | null): AsyncActionCreators<P, S, E>;
 }
 export default function actionCreatorFactory(prefix?: string | null, defaultIsError?: (payload: any) => boolean): ActionCreatorFactory;

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,21 @@ export interface AsyncActionCreators<P, S, E> {
   failed: ActionCreator<Failure<P, E>>;
 }
 
+export interface EmptySuccess<S> {
+  result: S;
+}
+
+export interface EmptyFailure<E> {
+  error: E;
+}
+
+export interface EmptyAsyncActionCreators<S, E> {
+  type: string;
+  started: EmptyActionCreator;
+  done: ActionCreator<EmptySuccess<S>>;
+  failed: ActionCreator<EmptyFailure<E>>;
+}
+
 export interface ActionCreatorFactory {
   (type: string, commonMeta?: Object | null,
    error?: boolean): EmptyActionCreator;
@@ -52,6 +67,9 @@ export interface ActionCreatorFactory {
 
   async<P, S>(type: string,
               commonMeta?: Object | null): AsyncActionCreators<P, S, any>;
+  async<undefined, S, E>(type: string,
+                         commonMeta?: Object | null,
+                         ): EmptyAsyncActionCreators<S, E>;
   async<P, S, E>(type: string,
                  commonMeta?: Object | null): AsyncActionCreators<P, S, E>;
 }


### PR DESCRIPTION
I guess `typescript-fsa` can't create no argument AsyncActionCreators now.

I don't know what style is good, however I want it.

#14 