### PR TITLE
Broken example from readme

### DIFF
--- a/tests/index.ts
+++ b/tests/index.ts
@@ -107,6 +107,17 @@ test('prefix', assert => {
   assert.end();
 });
 
+test('async readme example', assert => {
+  const actionCreator = actionCreatorFactory();
+  const doSomething =
+    actionCreator.async<{foo: string},   // parameter type
+                        {bar: number},   // success type
+                        {code: number}   // error type
+                       >('DO_SOMETHING');
+  assert.equal(doSomething.started({foo: 'lol'}).type, 'DO_SOMETHING_STARTED');
+  assert.end();
+});
+
 test('async', assert => {
   const actionCreator = actionCreatorFactory('prefix');
 


### PR DESCRIPTION
`yarn test` returns
```
TSError: ⨯ Unable to compile TypeScript
tests/index.ts (117,36): Argument of type '{ foo: string; }' is not assignable to parameter of type 'undefined'.
```
I suppose it is related to https://github.com/aikoven/typescript-fsa/commit/729b73aecbeb21565c854be27d3da0e97bcbc288