### PR TITLE
To address the new redux-saga action creator support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ export function actionCreatorFactory(
 
         return action;
       },
-      {type: fullType},
+      {type: fullType, toString: () => fullType},
     );
   }
 


### PR DESCRIPTION
Adding the `toString` field for better `redux-saga` support.

`redux-saga` docs mention this under [`take`](https://redux-saga.js.org/docs/api/) pattern:
>Note: if the pattern function has `toString` defined on it, `action.type` will be tested against `pattern.toString()` instead. This is useful if you're using an action creator library like `redux-act` or `redux-actions`.