### PR TITLE
Add ActionCreator#match method for single-argument type guard

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -19,9 +19,9 @@ export interface Failure<P, E> {
     error: E;
 }
 export declare function isType<P>(action: AnyAction, actionCreator: ActionCreator<P>): action is Action<P>;
-export declare function createTypeChecker<P>(actionCreator: ActionCreator<P>): (action: AnyAction) => action is Action<P>;
 export interface ActionCreator<P> {
     type: string;
+    match: (action: AnyAction) => action is Action<P>;
     (payload: P, meta?: Meta): Action<P>;
 }
 export interface EmptyActionCreator extends ActionCreator<undefined> {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -19,6 +19,7 @@ export interface Failure<P, E> {
     error: E;
 }
 export declare function isType<P>(action: AnyAction, actionCreator: ActionCreator<P>): action is Action<P>;
+export declare function createTypeChecker<P>(actionCreator: ActionCreator<P>): (action: AnyAction) => action is Action<P>;
 export interface ActionCreator<P> {
     type: string;
     (payload: P, meta?: Meta): Action<P>;

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,12 +4,6 @@ function isType(action, actionCreator) {
     return action.type === actionCreator.type;
 }
 exports.isType = isType;
-function createTypeChecker(actionCreator) {
-    return function (action) {
-        return isType(action, actionCreator);
-    };
-}
-exports.createTypeChecker = createTypeChecker;
 function actionCreatorFactory(prefix, defaultIsError) {
     if (defaultIsError === void 0) { defaultIsError = function (p) { return p instanceof Error; }; }
     var actionTypes = {};
@@ -34,7 +28,13 @@ function actionCreatorFactory(prefix, defaultIsError) {
                 action.error = true;
             }
             return action;
-        }, { type: fullType, toString: function () { return fullType; } });
+        }, {
+            type: fullType,
+            toString: function () { return fullType; },
+            match: function (action) {
+                return action.type === fullType;
+            },
+        });
     }
     function asyncActionCreators(type, commonMeta) {
         return {

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,12 @@ function isType(action, actionCreator) {
     return action.type === actionCreator.type;
 }
 exports.isType = isType;
+function createTypeChecker(actionCreator) {
+    return function (action) {
+        return isType(action, actionCreator);
+    };
+}
+exports.createTypeChecker = createTypeChecker;
 function actionCreatorFactory(prefix, defaultIsError) {
     if (defaultIsError === void 0) { defaultIsError = function (p) { return p instanceof Error; }; }
     var actionTypes = {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,11 @@ export function isType<P>(
   return action.type === actionCreator.type;
 }
 
+export function createTypeChecker<P>(actionCreator: ActionCreator<P>) {
+  return (action: AnyAction): action is Action<P> =>
+    isType(action, actionCreator);
+}
+
 export interface ActionCreator<P> {
   type: string;
   (payload: P, meta?: Meta): Action<P>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,13 +28,9 @@ export function isType<P>(
   return action.type === actionCreator.type;
 }
 
-export function createTypeChecker<P>(actionCreator: ActionCreator<P>) {
-  return (action: AnyAction): action is Action<P> =>
-    isType(action, actionCreator);
-}
-
 export interface ActionCreator<P> {
   type: string;
+  match: (action: AnyAction) => action is Action<P>;
   (payload: P, meta?: Meta): Action<P>;
 }
 
@@ -80,7 +76,7 @@ export function actionCreatorFactory(
 
   const base = prefix ? `${prefix}/` : "";
 
-  function actionCreator <P>(
+  function actionCreator<P>(
     type: string, commonMeta?: Meta,
     isError: ((payload: P) => boolean) | boolean = defaultIsError,
   ): ActionCreator<P> {
@@ -110,7 +106,12 @@ export function actionCreatorFactory(
 
         return action;
       },
-      {type: fullType, toString: () => fullType},
+      {
+        type: fullType,
+        toString: () => fullType,
+        match: (action: AnyAction): action is Action<P> =>
+          action.type === fullType,
+      },
     );
   }
 

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -17,6 +17,20 @@ test('isType', assert => {
   assert.end();
 });
 
+test('actionCreator.match', assert => {
+  const actionCreator = actionCreatorFactory();
+
+  const action1 = actionCreator('ACTION_1');
+  const action2 = actionCreator('ACTION_2');
+
+  const action = action1();
+
+  assert.true(action1.match(action));
+  assert.false(action2.match(action));
+
+  assert.end();
+});
+
 test('basic', assert => {
   const actionCreator = actionCreatorFactory();
 

--- a/tests/typings/index.ts
+++ b/tests/typings/index.ts
@@ -1,4 +1,4 @@
-import actionCreatorFactory, {isType, AnyAction} from "typescript-fsa";
+import actionCreatorFactory, {isType, createTypeChecker, AnyAction} from "typescript-fsa";
 
 
 declare const action: AnyAction;
@@ -77,6 +77,25 @@ function testIsType() {
   }
 
   if (isType(action, withoutPayload)) {
+    // typings:expect-error
+    const foo: {} = action.payload;
+  }
+}
+
+function testCreateTypeChecker() {
+  const withPayload = actionCreator<{foo: string}>('WITH_PAYLOAD');
+  const withoutPayload = actionCreator('WITHOUT_PAYLOAD');
+
+  const isWithPayload = createTypeChecker(withPayload)
+  if (isWithPayload(action)) {
+    const foo: string = action.payload.foo;
+
+    // typings:expect-error
+    action.payload.bar;
+  }
+
+  const isWithoutPayload = createTypeChecker(withoutPayload)
+  if (isWithoutPayload(action)) {
     // typings:expect-error
     const foo: {} = action.payload;
   }

--- a/tests/typings/index.ts
+++ b/tests/typings/index.ts
@@ -1,4 +1,4 @@
-import actionCreatorFactory, {isType, createTypeChecker, AnyAction} from "typescript-fsa";
+import actionCreatorFactory, {isType, AnyAction} from "typescript-fsa";
 
 
 declare const action: AnyAction;
@@ -82,20 +82,18 @@ function testIsType() {
   }
 }
 
-function testCreateTypeChecker() {
+function testMatch() {
   const withPayload = actionCreator<{foo: string}>('WITH_PAYLOAD');
   const withoutPayload = actionCreator('WITHOUT_PAYLOAD');
 
-  const isWithPayload = createTypeChecker(withPayload)
-  if (isWithPayload(action)) {
+  if (withPayload.match(action)) {
     const foo: string = action.payload.foo;
 
     // typings:expect-error
     action.payload.bar;
   }
 
-  const isWithoutPayload = createTypeChecker(withoutPayload)
-  if (isWithoutPayload(action)) {
+  if (withoutPayload.match(action)) {
     // typings:expect-error
     const foo: {} = action.payload;
   }


### PR DESCRIPTION
This is invaluable when using `redux-observable` since RxJS is written in typescript and has super solid type checking when the `Observable.prototype.filter` function gets a valid one-arg type guard.

I am open to changing the function name, I considered `createTypeGuard` or maybe something else.