### PR TITLE
Fix syntax error in the example given in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ console.log(doSomething.started({foo: 'lol'}));
 console.log(doSomething.done({
   params: {foo: 'lol'},
   result: {bar: 42},
-});
+}));
 // {type: 'DO_SOMETHING_DONE', payload: {
 //   params: {foo: 'lol'},
 //   result: {bar: 42},
@@ -71,7 +71,7 @@ console.log(doSomething.done({
 console.log(doSomething.failed({
   params: {foo: 'lol'},
   error: {code: 42},
-});
+}));
 // {type: 'DO_SOMETHING_FAILED', payload: {
 //   params: {foo: 'lol'},
 //   error: {code: 42},


### PR DESCRIPTION
This is a small PR to fix syntax errors in the example given in README.md

There is a missing closing bracket on the console.log. So, I've updated the README.md.