### PR TITLE
Fix types for undefined params

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -10,20 +10,24 @@ export interface Action<P> extends AnyAction {
     error?: boolean;
     meta?: Meta;
 }
-export declare type RequiredKeys<T> = {
-    [P in keyof T]: T[P] extends undefined ? never : P;
-}[keyof T];
-export declare type Optionalize<T> = Partial<T> & {
-    [P in RequiredKeys<T>]: T[P];
-};
-export declare type Success<P, S> = Optionalize<{
+export declare type Success<P, S> = (P extends undefined ? {
+    params?: P;
+} : {
     params: P;
+}) & (S extends undefined ? {
+    result?: S;
+} : {
     result: S;
-}>;
-export declare type Failure<P, E> = Optionalize<{
+});
+export declare type Failure<P, E> = (P extends undefined ? {
+    params?: P;
+} : {
     params: P;
+}) & (E extends undefined ? {
+    error?: E;
+} : {
     error: E;
-}>;
+});
 export declare function isType<P>(action: AnyAction, actionCreator: ActionCreator<P>): action is Action<P>;
 export declare type ActionCreator<P> = {
     type: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,22 +11,13 @@ export interface Action<P> extends AnyAction {
   meta?: Meta;
 }
 
+export type Success<P, S> =
+  (P extends undefined ? { params?: P; } : { params: P; }) &
+  (S extends undefined ? { result?: S; } : { result: S; });
 
-export type RequiredKeys<T> = {
-  [P in keyof T]: T[P] extends undefined ? never : P
-}[keyof T];
-// Makes all properties of type `undefined` optional
-export type Optionalize<T> = Partial<T> & {[P in RequiredKeys<T>]: T[P]};
-
-export type Success<P, S> = Optionalize<{
-  params: P;
-  result: S;
-}>;
-
-export type Failure<P, E> = Optionalize<{
-  params: P;
-  error: E;
-}>;
+export type Failure<P, E> =
+  (P extends undefined ? { params?: P; } : { params: P; }) &
+  (E extends undefined ? { error?: E; } : { error: E; });
 
 export function isType<P>(
   action: AnyAction,


### PR DESCRIPTION
Make the Success and Failure types simpler to fix the following problem.

If there is an action defined with:

    action = actionCreateFactory().async<undefined, S>('action');

i.e. its params are undefined, it still won't allow invocation without
the params, like:

    action.done({result: data as S})

but the following TypeScript error will be reported:

    error TS2345: Argument of type
    '{ result: S; }'
    is not assignable to parameter of type
    'Optionalize<{ params: undefined; result: S; }>'.